### PR TITLE
Get limits from the model instead of getting them from the controlboard

### DIFF
--- a/src/modelstate.cpp
+++ b/src/modelstate.cpp
@@ -137,6 +137,7 @@ void  ModelState::robotModel(std::string robotName)
   robotWBIModel = new wbiIcub::icubWholeBodyModel(localName.c_str(),robotName.c_str(),iCub::iDynTree::iCubTree_version_tag(2,2,true));
  // robotWBIModel->addJoints(wbiIcub::ICUB_MAIN_DYNAMIC_JOINTS);
   robotWBIModel->addJoints(wbiIcub::ICUB_MAIN_JOINTS);
+  robotWBIModel->getLimitsFromModel();
   mexPrintf("WholeBodyModel started with robot : %s, Num of Joints : %d \n",robotName.c_str(), robotWBIModel->getDoFs());
   if(!robotWBIModel->init())
   {


### PR DESCRIPTION
To address issue #2 . It should pointed out that getLimitsFromControlBoard() is a temporary yarpWholeBodyInterface specific function that in the future should be substituted with a proper way of specifying parameters to the wbi in a implementation-agnostic way. 